### PR TITLE
Add `ruff` to db

### DIFF
--- a/sync_with_poetry/db.py
+++ b/sync_with_poetry/db.py
@@ -35,4 +35,8 @@ DEPENDENCY_MAPPING = {
         "repo": "https://github.com/asottile/pyupgrade",
         "rev": "v${rev}",
     },
+    "ruff": {
+        "repo": "https://github.com/charliermarsh/ruff-pre-commit",
+        "rev": "v${rev}",
+    },
 }


### PR DESCRIPTION
[`ruff`](https://github.com/charliermarsh/ruff) is an extremely fast Python linter, written in Rust, with a separate [pre-commit repo](https://github.com/charliermarsh/ruff-pre-commit) that can be used.