### PR TITLE
Include ruff in db.py

### DIFF
--- a/sync_with_poetry/db.py
+++ b/sync_with_poetry/db.py
@@ -35,4 +35,8 @@ DEPENDENCY_MAPPING = {
         "repo": "https://github.com/asottile/pyupgrade",
         "rev": "v${rev}",
     },
+    "ruff": {
+        "repo": "https://github.com/charliermarsh/ruff-pre-commit",
+        "rev": "v${rev}",
+    },
 }


### PR DESCRIPTION
[Ruff](https://github.com/charliermarsh/ruff) is an increasingly popular linter. It is already used in several major open-source projects such as pandas and FastAPI, so it would be nice for this pre-commit hook to support it out of the box.