### PR TITLE
Implement `--allow-frozen` cmd option that enables support for frozen revisions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Excerpt from a `.pre-commit-config.yaml` using an example of this hook:
   --skip [SKIP ...]  Packages to skip
   --config CONFIG    Path to a custom .pre-commit-config.yaml file
   --db PACKAGE_LIST  Path to a custom package list (json)
+  --allow-frozen     Trust `frozen: xxx` comments for frozen revisions.
 ```
 
 Usually this hook uses only dev packages to sync the hooks. Pass `--all`, if you
@@ -94,6 +95,15 @@ defaults to `.pre-commit-config.yaml`).
 
 Pass `--db <package_list_file>` to point to an alternative package list (json).
 Such a file overrides the mapping in [`db.py`](sync_with_poetry/db.py).
+
+Pass `--allow-frozen` if you want to use frozen revisions in your config.
+Without this option _SWP_ will replace frozen revisions with the tag name taken
+from `poetry.lock` even if the frozen revision specifies the same commit as the
+tag. This options relies on `frozen: xxx` comments appended to the line of the
+frozen revision where `xxx` will be the tag name corresponding to the commit
+hash used. If the comment specifies the same revision as the lock file nothing
+is changed. Otherwise the revision is replaced with the expected revision tag
+and the `frozen: xxx` comment is removed.
 
 ## Supported packages
 

--- a/tests/test_frozen.py
+++ b/tests/test_frozen.py
@@ -1,0 +1,107 @@
+import pytest
+from py._path.local import LocalPath
+
+from sync_with_poetry import swp
+
+# test cases for frozen revisions
+# all these packages have version 1.0.0 in poetry.lock
+TEST_REVS = [
+    "    rev: 1.0.0\n",
+    "    rev: 1.0.0 # frozen\n",
+    "    rev: 1.0.0 # frozen: 2.0.0\n",
+    "    rev: 6fd1ced85fc139abd7f5ab4f3d78dab37592cd5e # frozen: 2.0.0\n",
+    "    rev: 6fd1ced85fc139abd7f5ab4f3d78dab37592cd5e # frozen: 1.0.0\n",
+    "    rev: 6fd1ced85fc139abd7f5ab4f3d78dab37592cd5e # frozen\n",
+    "    rev: 6fd1ced85fc139abd7f5ab4f3d78dab37592cd5e # frozen: 1.0.0 fav version\n",
+    "    rev: 6fd1ced85fc139abd7f5ab4f3d78dab37592cd5e # frozen: 2.0.0 fav version\n",
+    "    rev: 6fd1ced85fc139abd7f5ab4f3d78dab37592cd5e # fav version\n",
+    "    rev: 6fd1ced85fc139abd7f5ab4f3d78dab37592cd5e\n",
+]
+
+
+TEST_REVS_UNFROZEN = [
+    "    rev: 1.0.0\n",
+    "    rev: 1.0.0 # frozen\n",
+    "    rev: 1.0.0 # frozen: 2.0.0\n",
+    "    rev: 1.0.0\n",
+    "    rev: 1.0.0\n",
+    "    rev: 1.0.0 # frozen\n",
+    "    rev: 1.0.0 # fav version\n",
+    "    rev: 1.0.0 # fav version\n",
+    "    rev: 1.0.0 # fav version\n",
+    "    rev: 1.0.0\n",
+]
+
+TEST_REVS_FROZEN = [
+    "    rev: 1.0.0\n",
+    "    rev: 1.0.0 # frozen\n",
+    "    rev: 1.0.0 # frozen: 2.0.0\n",
+    "    rev: 1.0.0\n",
+    "    rev: 6fd1ced85fc139abd7f5ab4f3d78dab37592cd5e # frozen: 1.0.0\n",
+    "    rev: 1.0.0 # frozen\n",
+    "    rev: 6fd1ced85fc139abd7f5ab4f3d78dab37592cd5e # frozen: 1.0.0 fav version\n",
+    "    rev: 1.0.0 # fav version\n",
+    "    rev: 1.0.0 # fav version\n",
+    "    rev: 1.0.0\n",
+]
+
+assert len(TEST_REVS) == len(TEST_REVS_UNFROZEN) == len(TEST_REVS_FROZEN)
+
+
+def config_content(rev_line: str) -> str:
+    return (
+        "repos:\n" "  - repo: test\n" + rev_line + "    hooks:\n" "      - id: test\n"
+    )
+
+
+LOCK_CONTENT = (
+    "[[package]]\n"
+    'name = "test"\n'
+    'version = "1.0.0"\n'
+    'description = "a dummy package"\n'
+    "optional = false\n"
+    'python-versions = ">=3.6"\n'
+)
+
+
+DEPENDENCY_MAPPING = {
+    "test": {
+        "repo": "test",
+        "rev": "${rev}",
+    }
+}
+
+
+def run_and_check(
+    tmpdir: LocalPath, rev_line: str, expected: str, frozen: bool
+) -> None:
+    lock_file = tmpdir.join("poetry.lock")
+    lock_file.write(LOCK_CONTENT)
+    config_file = tmpdir.join(".pre-commit-yaml")
+    config = config_content(rev_line)
+    config_file.write(config)
+
+    retv = swp.sync_repos(
+        lock_file.strpath,
+        frozen=frozen,
+        db=DEPENDENCY_MAPPING,
+        config=config_file.strpath,
+    )
+
+    fixed_lines = open(config_file.strpath).readlines()
+    fixed_rev_line = fixed_lines[2]
+
+    assert fixed_rev_line == expected
+
+    assert len(config.splitlines()) == len(fixed_lines)
+    assert retv == int(expected != rev_line)
+
+
+@pytest.mark.parametrize("rev_line,expected", zip(TEST_REVS, TEST_REVS_UNFROZEN))
+def test_frozen_disabled(tmpdir: LocalPath, rev_line: str, expected: str) -> None:
+    run_and_check(tmpdir, rev_line, expected, frozen=False)
+
+
+@pytest.mark.parametrize("rev_line,expected", zip(TEST_REVS, TEST_REVS_FROZEN))
+def test_frozen_enabled(tmpdir: LocalPath, rev_line: str, expected: str) -> None:
+    run_and_check(tmpdir, rev_line, expected, frozen=True)


### PR DESCRIPTION
This new mode will trust `frozen: xxx` comments and use those to check frozen revisions.
If the comment specifies the same revision as the lock file nothing will be changed.
Otherwise the revision is replaced with expected revision tag.

* sync_with_poetry/swp.py

***

I implemented this for use with my new tool I mentioned in #24. So that I can enforce frozen revisions. Before this change the swp hook would always fail since my hook would freeze the revision.