### PR TITLE
Update DEPENDENCY_MAPPING in db.py

### DIFF
--- a/sync_with_poetry/db.py
+++ b/sync_with_poetry/db.py
@@ -1,26 +1,10 @@
 DEPENDENCY_MAPPING = {
-    "autopep8": {
-        "repo": "https://github.com/pre-commit/mirrors-autopep8",
+    "ruff": {
+        "repo": "https://github.com/charliermarsh/ruff-pre-commit",
         "rev": "v${rev}",
-    },
-    "bandit": {
-        "repo": "https://github.com/PyCQA/bandit",
-        "rev": "${rev}",
     },
     "black": {
-        "repo": "https://github.com/psf/black",
-        "rev": "${rev}",
-    },
-    "commitizen": {
-        "repo": "https://github.com/commitizen-tools/commitizen",
-        "rev": "v${rev}",
-    },
-    "flake8": {
-        "repo": "https://github.com/pycqa/flake8",
-        "rev": "${rev}",
-    },
-    "flakeheaven": {
-        "repo": "https://github.com/flakeheaven/flakeheaven",
+        "repo": "https://github.com/psf/black-pre-commit-mirror",
         "rev": "${rev}",
     },
     "isort": {
@@ -29,10 +13,6 @@ DEPENDENCY_MAPPING = {
     },
     "mypy": {
         "repo": "https://github.com/pre-commit/mirrors-mypy",
-        "rev": "v${rev}",
-    },
-    "pyupgrade": {
-        "repo": "https://github.com/asottile/pyupgrade",
         "rev": "v${rev}",
     },
 }


### PR DESCRIPTION
Revised the DEPENDENCY_MAPPING dictionary to include new mappings and remove obsolete ones. Dependencies like autopep8, bandit, Commitizen, flake8, flakeheaven, and pyupgrade have been removed. The ruff pre-commit hook and a new mirror for the black formatter have been added.