### PR TITLE
Fix files selector in .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,4 +3,4 @@
   description: Automatically sync pre-commit repos with package versions in poetry.lock
   entry: swp
   language: python
-  files: poetry.lock
+  files: poetry\.lock$


### PR DESCRIPTION
The `files` prop is a regexp, I got a bug where the precommit got blocked on a bash file called "resolve_poetry_lock_merge.sh" which this pre-commit tried to parse.